### PR TITLE
lower upper FOV limit from 130 to 110 (quake pro)

### DIFF
--- a/src/main/kotlin/dev/isxander/behindyou/config/Config.kt
+++ b/src/main/kotlin/dev/isxander/behindyou/config/Config.kt
@@ -68,7 +68,7 @@ object Config : Vigilant(File(BehindYou.modDir, "behindyouv3.toml"), "BehindYouV
         description = "Set the FOV when clicking on the behind keybind.",
         category = "General",
         min = 30,
-        max = 130
+        max = 110
     )
     var backFOV = 100
 
@@ -78,7 +78,7 @@ object Config : Vigilant(File(BehindYou.modDir, "behindyouv3.toml"), "BehindYouV
         description = "Set the FOV when clicking on the front keybind.",
         category = "General",
         min = 30,
-        max = 130
+        max = 110
     )
     var frontFOV = 100
 


### PR DESCRIPTION
## Description
We've had our fun with FOV values above 110/Quake Pro, now it's time to follow Patcher's footsteps to prevent upside down camera issues (set config values to 130 and fly around the main Hypixel lobby—or see below—for an example of what I mean).

## Related Issue(s)
— No specific issue number, just this image for demonstration for what I mean:
![image](https://user-images.githubusercontent.com/51521765/170834864-fb218aaf-4deb-4629-9d31-83e0c8ccd14b.png)

Fixes [N/A]
